### PR TITLE
Add admin panel for superadmin users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# ViewComponent for component-based views
+gem "view_component", "~> 3.20"
+
 # CSS framework
 gem "tailwindcss-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
+    method_source (1.1.0)
     metrics (0.12.2)
     mime-types (3.7.0)
       logger
@@ -513,6 +514,10 @@ GEM
     uri (1.0.3)
     useragent (0.16.11)
     version_gem (1.1.8)
+    view_component (3.23.2)
+      activesupport (>= 5.2.0, < 8.1)
+      concurrent-ruby (~> 1)
+      method_source (~> 1.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -568,6 +573,7 @@ DEPENDENCIES
   thruster
   turbo-rails
   tzinfo-data
+  view_component (~> 3.20)
   web-console
 
 BUNDLED WITH

--- a/app/components/admin/form_field_component.html.erb
+++ b/app/components/admin/form_field_component.html.erb
@@ -1,0 +1,25 @@
+<div class="mb-4">
+  <%= form.label attribute, label_text, class: "block text-sm font-medium text-gray-700 mb-1" %>
+  
+  <% case field_type %>
+  <% when :boolean %>
+    <div class="flex items-center">
+      <%= form.check_box attribute, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded", disabled: readonly? %>
+      <span class="ml-2 text-sm text-gray-600">Enable <%= label_text.downcase %></span>
+    </div>
+  <% when :text %>
+    <%= form.text_area attribute, rows: 4, class: field_classes, disabled: readonly? %>
+  <% when :number %>
+    <%= form.number_field attribute, class: field_classes, disabled: readonly? %>
+  <% when :datetime %>
+    <%= form.datetime_field attribute, class: field_classes, disabled: readonly? %>
+  <% when :date %>
+    <%= form.date_field attribute, class: field_classes, disabled: readonly? %>
+  <% else %>
+    <%= form.text_field attribute, class: field_classes, disabled: readonly? %>
+  <% end %>
+  
+  <% if model.errors[attribute].any? %>
+    <p class="mt-1 text-sm text-red-600"><%= model.errors[attribute].first %></p>
+  <% end %>
+</div>

--- a/app/components/admin/form_field_component.rb
+++ b/app/components/admin/form_field_component.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Admin::FormFieldComponent < ViewComponent::Base
+  def initialize(form:, attribute:, model:)
+    @form = form
+    @attribute = attribute
+    @model = model
+  end
+
+  private
+
+  attr_reader :form, :attribute, :model
+
+  def field_type
+    column = model.class.columns_hash[attribute.to_s]
+    return :association if association?
+    return :boolean if column&.type == :boolean
+    return :text if column&.type == :text
+    return :number if [:integer, :decimal, :float].include?(column&.type)
+    return :datetime if [:datetime, :timestamp].include?(column&.type)
+    return :date if column&.type == :date
+    :string
+  end
+
+  def association?
+    attribute.to_s.end_with?("_id") && model.class.reflect_on_all_associations.any? { |a| a.foreign_key == attribute.to_s }
+  end
+
+  def label_text
+    attribute.to_s.humanize
+  end
+
+  def field_classes
+    "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+  end
+
+  def readonly?
+    %w[id created_at updated_at].include?(attribute.to_s)
+  end
+end

--- a/app/components/admin/model_table_component.html.erb
+++ b/app/components/admin/model_table_component.html.erb
@@ -1,0 +1,43 @@
+<div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
+  <table class="min-w-full divide-y divide-gray-300">
+    <thead class="bg-gray-50">
+      <tr>
+        <% attributes.each do |attribute| %>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <%= attribute.humanize %>
+          </th>
+        <% end %>
+        <% if actions %>
+          <th scope="col" class="relative px-6 py-3">
+            <span class="sr-only">Actions</span>
+          </th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody class="bg-white divide-y divide-gray-200">
+      <% if models.any? %>
+        <% models.each do |model| %>
+          <tr class="hover:bg-gray-50">
+            <% attributes.each do |attribute| %>
+              <td class="px-6 py-4 text-sm text-gray-900 whitespace-nowrap">
+                <%= display_value(model, attribute) %>
+              </td>
+            <% end %>
+            <% if actions %>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <%= link_to "View", model_path(model), class: "text-indigo-600 hover:text-indigo-900 mr-3" %>
+                <%= link_to "Edit", edit_model_path(model), class: "text-indigo-600 hover:text-indigo-900" %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      <% else %>
+        <tr>
+          <td colspan="<%= attributes.length + (actions ? 1 : 0) %>" class="px-6 py-12 text-center text-sm text-gray-500">
+            No <%= model_name.downcase %> found
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/components/admin/model_table_component.rb
+++ b/app/components/admin/model_table_component.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Admin::ModelTableComponent < ViewComponent::Base
+  def initialize(models:, model_class:, actions: true)
+    @models = models
+    @model_class = model_class
+    @actions = actions
+  end
+
+  private
+
+  attr_reader :models, :model_class, :actions
+
+  def attributes
+    @attributes ||= model_class.column_names - %w[created_at updated_at]
+  end
+
+  def display_value(model, attribute)
+    value = model.send(attribute)
+    
+    case value
+    when ActiveSupport::TimeWithZone
+      value.strftime("%Y-%m-%d %H:%M")
+    when Date
+      value.strftime("%Y-%m-%d")
+    when TrueClass
+      content_tag(:span, "Yes", class: "px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full")
+    when FalseClass
+      content_tag(:span, "No", class: "px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full")
+    when NilClass
+      content_tag(:span, "—", class: "text-gray-400")
+    else
+      value.to_s.truncate(50)
+    end
+  end
+
+  def model_path(model)
+    send("admin_#{model.class.name.underscore}_path", model)
+  end
+
+  def edit_model_path(model)
+    send("edit_admin_#{model.class.name.underscore}_path", model)
+  end
+
+  def model_name
+    model_class.name.pluralize
+  end
+end

--- a/app/components/admin/sidebar_component.html.erb
+++ b/app/components/admin/sidebar_component.html.erb
@@ -1,0 +1,24 @@
+<aside class="w-64 bg-white shadow-sm h-full">
+  <div class="px-6 py-4 border-b">
+    <h1 class="text-xl font-bold text-gray-900">Admin Panel</h1>
+  </div>
+  
+  <nav class="mt-6">
+    <h2 class="px-6 text-xs font-semibold text-gray-400 uppercase tracking-wider">Models</h2>
+    <div class="mt-2">
+      <% models.each do |model| %>
+        <%= link_to model[:name], model[:path], class: nav_link_classes(model[:path]) %>
+      <% end %>
+    </div>
+  </nav>
+  
+  <div class="absolute bottom-0 w-64 p-6 border-t">
+    <div class="flex items-center">
+      <div class="flex-1">
+        <p class="text-sm font-medium text-gray-900"><%= current_user.name %></p>
+        <p class="text-xs text-gray-500">Superadmin</p>
+      </div>
+      <%= link_to "Logout", logout_path, method: :delete, data: { turbo_method: :delete }, class: "text-sm text-red-600 hover:text-red-700" %>
+    </div>
+  </div>
+</aside>

--- a/app/components/admin/sidebar_component.rb
+++ b/app/components/admin/sidebar_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Admin::SidebarComponent < ViewComponent::Base
+  def initialize(current_path:)
+    @current_path = current_path
+  end
+
+  private
+
+  attr_reader :current_path
+
+  def nav_link_classes(path)
+    base_classes = "flex items-center px-6 py-3 text-sm font-medium transition-colors hover:bg-gray-100"
+    active_classes = "bg-gray-100 text-gray-900 border-r-2 border-gray-900"
+    inactive_classes = "text-gray-600"
+    
+    is_active = current_path.start_with?(path)
+    "#{base_classes} #{is_active ? active_classes : inactive_classes}"
+  end
+
+  def models
+    [
+      { name: "Users", path: admin_users_path },
+      { name: "Roles", path: admin_roles_path }
+    ]
+  end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,12 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_superadmin
+
+  private
+
+  def require_superadmin
+    unless current_user&.superadmin?
+      flash[:alert] = "You must be a superadmin to access this area"
+      redirect_to root_path
+    end
+  end
+end

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -1,0 +1,52 @@
+class Admin::RolesController < Admin::BaseController
+  layout "admin"
+  before_action :set_role, only: %i[show edit update destroy]
+
+  def index
+    @roles = Role.order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @role = Role.new
+  end
+
+  def edit
+  end
+
+  def create
+    @role = Role.new(role_params)
+
+    if @role.save
+      redirect_to admin_role_path(@role), notice: "Role was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @role.update(role_params)
+      redirect_to admin_role_path(@role), notice: "Role was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @role.destroy!
+    redirect_to admin_roles_url, notice: "Role was successfully destroyed."
+  end
+
+  private
+
+  def set_role
+    @role = Role.find(params[:id])
+  end
+
+  def role_params
+    permitted_attributes = Role.column_names - ["id", "created_at", "updated_at"]
+    params.require(:role).permit(*permitted_attributes)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,64 @@
+class Admin::UsersController < Admin::BaseController
+  layout "admin"
+  before_action :set_user, only: %i[show edit update destroy]
+
+  def index
+    @users = User.includes(:roles).order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def edit
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      handle_superadmin_role
+      redirect_to admin_user_path(@user), notice: "User was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      handle_superadmin_role
+      redirect_to admin_user_path(@user), notice: "User was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @user.destroy!
+    redirect_to admin_users_url, notice: "User was successfully destroyed."
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    permitted_attributes = User.column_names - ["id", "created_at", "updated_at"]
+    params.require(:user).permit(*permitted_attributes)
+  end
+
+  def handle_superadmin_role
+    return unless params[:user][:is_superadmin].present?
+
+    if params[:user][:is_superadmin] == "1"
+      @user.make_superadmin!
+    else
+      @user.remove_superadmin!
+    end
+  end
+end

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    setTimeout(() => {
+      this.element.style.transition = "opacity 0.5s ease-in-out"
+      this.element.style.opacity = "0"
+      
+      setTimeout(() => {
+        this.element.remove()
+      }, 500)
+    }, 3000)
+  }
+}

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: [:admin, role], local: true, data: { turbo: false }) do |form| %>
+  <% if role.errors.any? %>
+    <div class="rounded-md bg-red-50 p-4 mb-6">
+      <div class="flex">
+        <div class="ml-3">
+          <h3 class="text-sm font-medium text-red-800">
+            There were <%= pluralize(role.errors.count, "error") %> with your submission
+          </h3>
+          <div class="mt-2 text-sm text-red-700">
+            <ul class="list-disc pl-5 space-y-1">
+              <% role.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="space-y-6">
+    <% Role.column_names.each do |attribute| %>
+      <% next if %w[id created_at updated_at].include?(attribute) %>
+      <%= render Admin::FormFieldComponent.new(form: form, attribute: attribute, model: role) %>
+    <% end %>
+  </div>
+
+  <div class="mt-8 flex gap-3">
+    <%= form.submit class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+    <%= link_to "Cancel", admin_roles_path, class: "inline-flex justify-center py-2 px-4 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+  </div>
+<% end %>

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-gray-900">Edit Role</h1>
+  <p class="mt-2 text-sm text-gray-700">Update role information</p>
+</div>
+
+<div class="bg-white shadow sm:rounded-lg">
+  <div class="px-4 py-5 sm:p-6">
+    <%= render "form", role: @role %>
+  </div>
+</div>
+
+<div class="mt-6">
+  <%= button_to "Delete Role", admin_role_path(@role), method: :delete, 
+      data: { confirm: "Are you sure you want to delete this role? This action cannot be undone.", turbo_confirm: "Are you sure you want to delete this role? This action cannot be undone." },
+      class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
+</div>

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,0 +1,13 @@
+<div class="sm:flex sm:items-center">
+  <div class="sm:flex-auto">
+    <h1 class="text-2xl font-semibold text-gray-900">Roles</h1>
+    <p class="mt-2 text-sm text-gray-700">A list of all roles in the system</p>
+  </div>
+  <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+    <%= link_to "New Role", new_admin_role_path, class: "block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+  </div>
+</div>
+
+<div class="mt-8">
+  <%= render Admin::ModelTableComponent.new(models: @roles, model_class: Role) %>
+</div>

--- a/app/views/admin/roles/new.html.erb
+++ b/app/views/admin/roles/new.html.erb
@@ -1,0 +1,10 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-gray-900">New Role</h1>
+  <p class="mt-2 text-sm text-gray-700">Create a new role</p>
+</div>
+
+<div class="bg-white shadow sm:rounded-lg">
+  <div class="px-4 py-5 sm:p-6">
+    <%= render "form", role: @role %>
+  </div>
+</div>

--- a/app/views/admin/roles/show.html.erb
+++ b/app/views/admin/roles/show.html.erb
@@ -1,0 +1,66 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-gray-900">Role Details</h1>
+</div>
+
+<div class="bg-white shadow overflow-hidden sm:rounded-lg">
+  <div class="px-4 py-5 sm:px-6">
+    <h3 class="text-lg leading-6 font-medium text-gray-900">
+      <%= @role.name %>
+    </h3>
+    <p class="mt-1 max-w-2xl text-sm text-gray-500">
+      Role ID: <%= @role.id %>
+    </p>
+  </div>
+  <div class="border-t border-gray-200">
+    <dl>
+      <% Role.column_names.each_with_index do |attribute, index| %>
+        <div class="<%= index.even? ? 'bg-gray-50' : 'bg-white' %> px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500">
+            <%= attribute.humanize %>
+          </dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+            <% value = @role.send(attribute) %>
+            <% case value %>
+            <% when ActiveSupport::TimeWithZone %>
+              <%= value.strftime("%B %d, %Y at %I:%M %p") %>
+            <% when Date %>
+              <%= value.strftime("%B %d, %Y") %>
+            <% when TrueClass %>
+              <span class="px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">Yes</span>
+            <% when FalseClass %>
+              <span class="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full">No</span>
+            <% when NilClass %>
+              <span class="text-gray-400">—</span>
+            <% else %>
+              <%= value %>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+      
+      <div class="<%= Role.column_names.length.even? ? 'bg-gray-50' : 'bg-white' %> px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+        <dt class="text-sm font-medium text-gray-500">
+          Users with this role
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+          <% if @role.users.any? %>
+            <div class="flex flex-wrap gap-2">
+              <% @role.users.each do |user| %>
+                <%= link_to admin_user_path(user), class: "inline-flex items-center px-2.5 py-1.5 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" do %>
+                  <%= user.name || user.email %>
+                <% end %>
+              <% end %>
+            </div>
+          <% else %>
+            <span class="text-gray-400">No users assigned</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<div class="mt-6 flex gap-3">
+  <%= link_to "Edit", edit_admin_role_path(@role), class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+  <%= link_to "Back to Roles", admin_roles_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+</div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with(model: [:admin, user], local: true, data: { turbo: false }) do |form| %>
+  <% if user.errors.any? %>
+    <div class="rounded-md bg-red-50 p-4 mb-6">
+      <div class="flex">
+        <div class="ml-3">
+          <h3 class="text-sm font-medium text-red-800">
+            There were <%= pluralize(user.errors.count, "error") %> with your submission
+          </h3>
+          <div class="mt-2 text-sm text-red-700">
+            <ul class="list-disc pl-5 space-y-1">
+              <% user.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="space-y-6">
+    <% User.column_names.each do |attribute| %>
+      <% next if %w[id created_at updated_at].include?(attribute) %>
+      <%= render Admin::FormFieldComponent.new(form: form, attribute: attribute, model: user) %>
+    <% end %>
+    
+    <div class="mb-4">
+      <label class="block text-sm font-medium text-gray-700 mb-1">Superadmin Status</label>
+      <div class="flex items-center">
+        <%= check_box_tag "user[is_superadmin]", "1", user.superadmin?, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
+        <label for="user_is_superadmin" class="ml-2 text-sm text-gray-600">
+          Grant superadmin privileges
+        </label>
+      </div>
+      <p class="mt-1 text-xs text-gray-500">Superadmins have full access to the admin panel</p>
+    </div>
+  </div>
+
+  <div class="mt-8 flex gap-3">
+    <%= form.submit class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+    <%= link_to "Cancel", admin_users_path, class: "inline-flex justify-center py-2 px-4 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+  </div>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-gray-900">Edit User</h1>
+  <p class="mt-2 text-sm text-gray-700">Update user information</p>
+</div>
+
+<div class="bg-white shadow sm:rounded-lg">
+  <div class="px-4 py-5 sm:p-6">
+    <%= render "form", user: @user %>
+  </div>
+</div>
+
+<div class="mt-6">
+  <%= button_to "Delete User", admin_user_path(@user), method: :delete, 
+      data: { confirm: "Are you sure you want to delete this user? This action cannot be undone.", turbo_confirm: "Are you sure you want to delete this user? This action cannot be undone." },
+      class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,13 @@
+<div class="sm:flex sm:items-center">
+  <div class="sm:flex-auto">
+    <h1 class="text-2xl font-semibold text-gray-900">Users</h1>
+    <p class="mt-2 text-sm text-gray-700">A list of all users in the system</p>
+  </div>
+  <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+    <%= link_to "New User", new_admin_user_path, class: "block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+  </div>
+</div>
+
+<div class="mt-8">
+  <%= render Admin::ModelTableComponent.new(models: @users, model_class: User) %>
+</div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,10 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-gray-900">New User</h1>
+  <p class="mt-2 text-sm text-gray-700">Create a new user account</p>
+</div>
+
+<div class="bg-white shadow sm:rounded-lg">
+  <div class="px-4 py-5 sm:p-6">
+    <%= render "form", user: @user %>
+  </div>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,77 @@
+<div class="mb-6">
+  <h1 class="text-2xl font-semibold text-gray-900">User Details</h1>
+</div>
+
+<div class="bg-white shadow overflow-hidden sm:rounded-lg">
+  <div class="px-4 py-5 sm:px-6">
+    <h3 class="text-lg leading-6 font-medium text-gray-900">
+      <%= @user.name || @user.email %>
+    </h3>
+    <p class="mt-1 max-w-2xl text-sm text-gray-500">
+      User ID: <%= @user.id %>
+    </p>
+  </div>
+  <div class="border-t border-gray-200">
+    <dl>
+      <% User.column_names.each_with_index do |attribute, index| %>
+        <div class="<%= index.even? ? 'bg-gray-50' : 'bg-white' %> px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500">
+            <%= attribute.humanize %>
+          </dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+            <% value = @user.send(attribute) %>
+            <% case value %>
+            <% when ActiveSupport::TimeWithZone %>
+              <%= value.strftime("%B %d, %Y at %I:%M %p") %>
+            <% when Date %>
+              <%= value.strftime("%B %d, %Y") %>
+            <% when TrueClass %>
+              <span class="px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">Yes</span>
+            <% when FalseClass %>
+              <span class="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full">No</span>
+            <% when NilClass %>
+              <span class="text-gray-400">—</span>
+            <% else %>
+              <%= value %>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+      
+      <div class="<%= User.column_names.length.even? ? 'bg-gray-50' : 'bg-white' %> px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+        <dt class="text-sm font-medium text-gray-500">
+          Roles
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+          <% if @user.roles.any? %>
+            <div class="flex flex-wrap gap-2">
+              <% @user.roles.each do |role| %>
+                <span class="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full"><%= role.name %></span>
+              <% end %>
+            </div>
+          <% else %>
+            <span class="text-gray-400">No roles assigned</span>
+          <% end %>
+        </dd>
+      </div>
+      
+      <div class="<%= (User.column_names.length + 1).even? ? 'bg-gray-50' : 'bg-white' %> px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+        <dt class="text-sm font-medium text-gray-500">
+          Is Superadmin
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+          <% if @user.superadmin? %>
+            <span class="px-2 py-1 text-xs font-medium bg-red-100 text-red-800 rounded-full">Superadmin</span>
+          <% else %>
+            <span class="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full">Regular User</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<div class="mt-6 flex gap-3">
+  <%= link_to "Edit", edit_admin_user_path(@user), class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+  <%= link_to "Back to Users", admin_users_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Admin - Eight</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= yield :head %>
+
+    <link rel="manifest" href="/manifest.json">
+    <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body class="bg-gray-50">
+    <div class="flex h-screen">
+      <%= render Admin::SidebarComponent.new(current_path: request.path) %>
+      
+      <main class="flex-1 overflow-y-auto">
+        <div class="px-8 py-6">
+          <% if flash[:notice].present? %>
+            <div class="mb-4 p-4 bg-green-50 border border-green-200 text-green-800 rounded-lg" data-controller="flash">
+              <%= flash[:notice] %>
+            </div>
+          <% end %>
+          
+          <% if flash[:alert].present? %>
+            <div class="mb-4 p-4 bg-red-50 border border-red-200 text-red-800 rounded-lg" data-controller="flash">
+              <%= flash[:alert] %>
+            </div>
+          <% end %>
+          
+          <%= yield %>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,13 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "sessions#failure"
   delete "/logout", to: "sessions#destroy"
 
+  # Admin routes
+  namespace :admin do
+    resources :users
+    resources :roles
+    root "users#index"
+  end
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/test/components/admin/form_field_component_test.rb
+++ b/test/components/admin/form_field_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::FormFieldComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Admin::FormFieldComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end

--- a/test/components/admin/model_table_component_test.rb
+++ b/test/components/admin/model_table_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::ModelTableComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Admin::ModelTableComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end

--- a/test/components/admin/sidebar_component_test.rb
+++ b/test/components/admin/sidebar_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::SidebarComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Admin::SidebarComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end


### PR DESCRIPTION
## Summary
- Added a comprehensive admin panel accessible only by superadmin users
- Implemented full CRUD operations for Users and Roles models
- Created dynamic, reusable components that automatically adapt to model attribute changes

## Features
- **Admin Authentication**: Created `Admin::BaseController` that ensures only superadmin users can access admin panel
- **Dynamic Views**: Built with ViewComponent for reusable UI components
- **Model Management**: 
  - Users: Full CRUD with ability to grant/revoke superadmin status
  - Roles: Full CRUD operations
- **Smart Components**:
  - `FormFieldComponent`: Automatically renders appropriate form fields based on attribute type
  - `ModelTableComponent`: Dynamically displays model data in tables
- **UX Enhancements**:
  - Auto-dismissing flash messages with Stimulus
  - Responsive Tailwind CSS design
  - Sidebar navigation for easy model switching

## Test plan
- [ ] Login as a superadmin user
- [ ] Navigate to `/admin`
- [ ] Test Users CRUD operations:
  - [ ] View users list
  - [ ] Create a new user
  - [ ] Edit existing user
  - [ ] Toggle superadmin status
  - [ ] Delete a user
- [ ] Test Roles CRUD operations:
  - [ ] View roles list
  - [ ] Create a new role
  - [ ] Edit existing role
  - [ ] Delete a role
- [ ] Verify non-superadmin users cannot access admin panel
- [ ] Test flash message auto-dismiss functionality
- [ ] Verify dynamic field rendering works for all attribute types

🤖 Generated with [Claude Code](https://claude.ai/code)