### PR TITLE
Add blog feature with SEO, i18n, and tagging support

### DIFF
--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -1,0 +1,33 @@
+class BlogPostsController < ApplicationController
+  before_action :set_blog_post, only: [:show]
+  
+  def index
+    @blog_posts = BlogPost.published.recent.includes(:user, :tags)
+    
+    # Simple pagination without kaminari
+    page = (params[:page] || 1).to_i
+    per_page = 9
+    @blog_posts = @blog_posts.limit(per_page).offset((page - 1) * per_page)
+    
+    respond_to do |format|
+      format.html
+      format.rss { render layout: false }
+      format.atom { render layout: false }
+    end
+  end
+  
+  def show
+    unless @blog_post.published? || (logged_in? && (current_user == @blog_post.user || current_user.superadmin?))
+      redirect_to blog_posts_path, alert: t('blog_posts.not_found')
+      return
+    end
+    
+    @blog_post.increment_views! if @blog_post.published?
+  end
+  
+  private
+  
+  def set_blog_post
+    @blog_post = BlogPost.includes(:user, :tags).find_by!(slug: params[:id])
+  end
+end

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -1,0 +1,76 @@
+class BlogPost < ApplicationRecord
+  belongs_to :user
+  has_many :taggings, as: :taggable, dependent: :destroy
+  has_many :tags, through: :taggings
+  
+  # Status enum
+  enum :status, { draft: 0, published: 1, archived: 2 }
+  
+  # Validations
+  validates :title, presence: true
+  validates :slug, presence: true, uniqueness: true
+  validates :content, presence: true
+  
+  # Scopes
+  scope :published, -> { where(status: :published).where('published_at <= ?', Time.current) }
+  scope :recent, -> { order(published_at: :desc) }
+  scope :featured, -> { where.not(featured_image_url: nil) }
+  
+  # Callbacks
+  before_validation :generate_slug, if: -> { slug.blank? && title.present? }
+  before_validation :set_published_at, if: -> { status_changed? && published? }
+  before_save :calculate_reading_time
+  before_save :set_seo_defaults
+  
+  # Instance methods
+  def to_param
+    slug
+  end
+  
+  def published?
+    status == 'published' && published_at.present? && published_at <= Time.current
+  end
+  
+  def increment_views!
+    increment!(:views_count)
+  end
+  
+  def tag_list
+    tags.pluck(:name).join(', ')
+  end
+  
+  def tag_list=(names)
+    self.tags = names.split(',').map do |name|
+      Tag.where(name: name.strip).first_or_create!
+    end
+  end
+  
+  private
+  
+  def generate_slug
+    self.slug = title.parameterize
+    # Ensure uniqueness
+    if BlogPost.where.not(id: id).exists?(slug: slug)
+      self.slug = "#{slug}-#{SecureRandom.hex(4)}"
+    end
+  end
+  
+  def set_published_at
+    self.published_at ||= Time.current if published?
+  end
+  
+  def calculate_reading_time
+    return unless content.present?
+    word_count = content.split.size
+    self.reading_time_minutes = (word_count / 200.0).ceil # Average reading speed: 200 words/minute
+  end
+  
+  def set_seo_defaults
+    self.meta_title ||= title
+    self.meta_description ||= excerpt || content.truncate(160)
+    self.og_title ||= meta_title
+    self.og_description ||= meta_description
+    self.twitter_title ||= meta_title
+    self.twitter_description ||= meta_description
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,24 @@
+class Tag < ApplicationRecord
+  has_many :taggings, dependent: :destroy
+  has_many :blog_posts, through: :taggings, source: :taggable, source_type: 'BlogPost'
+  
+  # Validations
+  validates :name, presence: true, uniqueness: true
+  validates :slug, presence: true, uniqueness: true
+  
+  # Callbacks
+  before_validation :generate_slug, if: -> { slug.blank? && name.present? }
+  
+  # Scopes
+  scope :popular, -> { joins(:taggings).group(:id).order('COUNT(taggings.id) DESC') }
+  
+  def to_param
+    slug
+  end
+  
+  private
+  
+  def generate_slug
+    self.slug = name.parameterize
+  end
+end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,7 @@
+class Tagging < ApplicationRecord
+  belongs_to :tag
+  belongs_to :taggable, polymorphic: true
+  
+  # Validations
+  validates :tag_id, uniqueness: { scope: [:taggable_type, :taggable_id] }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,4 +45,7 @@ class User < ApplicationRecord
   def remove_superadmin!
     roles.delete(Role.superadmin) if superadmin?
   end
+  
+  # Associations
+  has_many :blog_posts, dependent: :destroy
 end

--- a/app/views/blog_posts/index.atom.builder
+++ b/app/views/blog_posts/index.atom.builder
@@ -1,0 +1,20 @@
+atom_feed do |feed|
+  feed.title t('blog_posts.atom.title', default: 'Blog - Eight')
+  feed.updated @blog_posts.maximum(:updated_at) || Time.current
+
+  @blog_posts.each do |blog_post|
+    feed.entry blog_post, published: blog_post.published_at do |entry|
+      entry.title blog_post.title
+      entry.content blog_post.content, type: 'html'
+      
+      entry.author do |author|
+        author.name blog_post.user.name
+        author.email blog_post.user.email
+      end
+      
+      blog_post.tags.each do |tag|
+        entry.category term: tag.slug, label: tag.name
+      end
+    end
+  end
+end

--- a/app/views/blog_posts/index.html.erb
+++ b/app/views/blog_posts/index.html.erb
@@ -1,0 +1,72 @@
+<div class="container mx-auto px-4 py-8 max-w-7xl">
+  <!-- NYT-style header -->
+  <header class="border-b-4 border-black mb-8">
+    <h1 class="text-5xl font-serif font-bold mb-4"><%= t('blog_posts.index.title', default: 'The Blog') %></h1>
+    <p class="text-gray-600 mb-4"><%= t('blog_posts.index.subtitle', default: 'Latest insights and updates') %></p>
+  </header>
+
+  <!-- Blog posts grid -->
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+    <% @blog_posts.each_with_index do |blog_post, index| %>
+      <article class="<%= 'lg:col-span-2 lg:row-span-2' if index == 0 %> border-b pb-8 mb-8">
+        <%= link_to blog_post_path(blog_post), class: "group block" do %>
+          <% if blog_post.featured_image_url.present? %>
+            <div class="mb-4 overflow-hidden <%= index == 0 ? 'h-96' : 'h-48' %>">
+              <%= image_tag blog_post.featured_image_url, 
+                  alt: blog_post.featured_image_alt || blog_post.title,
+                  class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" %>
+            </div>
+          <% end %>
+          
+          <div class="space-y-2">
+            <% if blog_post.tags.any? %>
+              <div class="flex gap-2 flex-wrap">
+                <% blog_post.tags.limit(3).each do |tag| %>
+                  <span class="text-xs font-semibold uppercase tracking-wider text-red-600">
+                    <%= tag.name %>
+                  </span>
+                <% end %>
+              </div>
+            <% end %>
+            
+            <h2 class="text-<%= index == 0 ? '3xl' : '2xl' %> font-serif font-bold leading-tight group-hover:underline">
+              <%= blog_post.title %>
+            </h2>
+            
+            <% if blog_post.excerpt.present? %>
+              <p class="text-gray-700 <%= index == 0 ? 'text-lg' : '' %> line-clamp-3">
+                <%= blog_post.excerpt %>
+              </p>
+            <% end %>
+            
+            <div class="flex items-center text-sm text-gray-600 pt-2">
+              <span class="font-semibold"><%= blog_post.user.name %></span>
+              <span class="mx-2">·</span>
+              <time datetime="<%= blog_post.published_at.iso8601 %>">
+                <%= l(blog_post.published_at, format: :long) %>
+              </time>
+              <% if blog_post.reading_time_minutes.present? %>
+                <span class="mx-2">·</span>
+                <span><%= t('blog_posts.reading_time', count: blog_post.reading_time_minutes, default: '%{count} min read') %></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </article>
+    <% end %>
+  </div>
+
+  <!-- Simple pagination -->
+  <% if @blog_posts.size == 9 || params[:page].to_i > 1 %>
+    <nav class="mt-12 flex justify-center space-x-2">
+      <% if params[:page].to_i > 1 %>
+        <%= link_to "← Previous", blog_posts_path(page: params[:page].to_i - 1), 
+            class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-100" %>
+      <% end %>
+      <% if @blog_posts.size == 9 %>
+        <%= link_to "Next →", blog_posts_path(page: (params[:page] || 1).to_i + 1), 
+            class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-100" %>
+      <% end %>
+    </nav>
+  <% end %>
+</div>

--- a/app/views/blog_posts/index.rss.builder
+++ b/app/views/blog_posts/index.rss.builder
@@ -1,0 +1,25 @@
+xml.instruct! :xml, version: "1.0"
+xml.rss version: "2.0" do
+  xml.channel do
+    xml.title t('blog_posts.rss.title', default: 'Blog - Eight')
+    xml.description t('blog_posts.rss.description', default: 'Latest blog posts from Eight')
+    xml.link blog_posts_url
+    xml.language I18n.locale.to_s
+
+    @blog_posts.each do |blog_post|
+      xml.item do
+        xml.title blog_post.title
+        xml.description blog_post.excerpt || blog_post.content.to_s.gsub(/<[^>]*>/, '').truncate(300)
+        xml.pubDate blog_post.published_at.to_s(:rfc822)
+        xml.link blog_post_url(blog_post)
+        xml.guid blog_post_url(blog_post)
+        
+        blog_post.tags.each do |tag|
+          xml.category tag.name
+        end
+        
+        xml.author "#{blog_post.user.email} (#{blog_post.user.name})"
+      end
+    end
+  end
+end

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -1,0 +1,116 @@
+<article class="container mx-auto px-4 py-8 max-w-4xl">
+  <!-- Article header -->
+  <header class="mb-8">
+    <% if @blog_post.tags.any? %>
+      <div class="flex gap-2 flex-wrap mb-4">
+        <% @blog_post.tags.each do |tag| %>
+          <span class="text-xs font-semibold uppercase tracking-wider text-red-600">
+            <%= tag.name %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+    
+    <h1 class="text-4xl md:text-5xl font-serif font-bold leading-tight mb-4">
+      <%= @blog_post.title %>
+    </h1>
+    
+    <% if @blog_post.excerpt.present? %>
+      <p class="text-xl text-gray-700 mb-6 font-serif italic">
+        <%= @blog_post.excerpt %>
+      </p>
+    <% end %>
+    
+    <div class="flex items-center text-gray-600 border-t border-b border-gray-300 py-4">
+      <div class="flex-1">
+        <div class="font-semibold text-black"><%= @blog_post.user.name %></div>
+        <time datetime="<%= @blog_post.published_at.iso8601 %>" class="text-sm">
+          <%= l(@blog_post.published_at, format: :long) %>
+        </time>
+      </div>
+      <% if @blog_post.reading_time_minutes.present? %>
+        <div class="text-sm">
+          <%= t('blog_posts.reading_time', count: @blog_post.reading_time_minutes, default: '%{count} min read') %>
+        </div>
+      <% end %>
+    </div>
+  </header>
+
+  <!-- Featured image -->
+  <% if @blog_post.featured_image_url.present? %>
+    <figure class="mb-8">
+      <%= image_tag @blog_post.featured_image_url, 
+          alt: @blog_post.featured_image_alt || @blog_post.title,
+          class: "w-full rounded-lg shadow-lg" %>
+      <% if @blog_post.featured_image_alt.present? %>
+        <figcaption class="text-sm text-gray-600 mt-2 text-center italic">
+          <%= @blog_post.featured_image_alt %>
+        </figcaption>
+      <% end %>
+    </figure>
+  <% end %>
+
+  <!-- Article content -->
+  <div class="prose prose-lg max-w-none font-serif">
+    <%= simple_format(@blog_post.content) %>
+  </div>
+
+  <!-- Article footer -->
+  <footer class="mt-12 pt-8 border-t border-gray-300">
+    <div class="flex items-center justify-between">
+      <div class="text-sm text-gray-600">
+        <%= t('blog_posts.views', count: @blog_post.views_count, default: '%{count} views') %>
+      </div>
+      
+      <% if logged_in? && (current_user == @blog_post.user || current_user.superadmin?) %>
+        <div class="flex gap-4">
+          <%= link_to t('blog_posts.edit'), "#", 
+              class: "text-blue-600 hover:underline" %>
+        </div>
+      <% end %>
+    </div>
+    
+    <!-- Back to blog link -->
+    <div class="mt-8">
+      <%= link_to blog_posts_path, class: "inline-flex items-center text-blue-600 hover:underline" do %>
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        <%= t('blog_posts.back_to_blog', default: 'Back to Blog') %>
+      <% end %>
+    </div>
+  </footer>
+</article>
+
+<!-- Structured data for SEO -->
+<% if @blog_post.structured_data.present? %>
+  <script type="application/ld+json">
+    <%= @blog_post.structured_data.to_json.html_safe %>
+  </script>
+<% else %>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      "headline": <%= @blog_post.title.to_json.html_safe %>,
+      "description": <%= (@blog_post.excerpt || @blog_post.meta_description).to_json.html_safe %>,
+      "author": {
+        "@type": "Person",
+        "name": <%= @blog_post.user.name.to_json.html_safe %>
+      },
+      "datePublished": <%= @blog_post.published_at.iso8601.to_json.html_safe %>,
+      "dateModified": <%= @blog_post.updated_at.iso8601.to_json.html_safe %>,
+      <% if @blog_post.featured_image_url.present? %>
+      "image": <%= @blog_post.featured_image_url.to_json.html_safe %>,
+      <% end %>
+      "publisher": {
+        "@type": "Organization",
+        "name": <%= Rails.application.config.application_name.to_json.html_safe rescue "Eight".to_json.html_safe %>
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": <%= blog_post_url(@blog_post).to_json.html_safe %>
+      }
+    }
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
         <%= link_to "Eight", root_path, class: "text-2xl font-bold" %>
         
         <div class="flex items-center space-x-4">
+          <%= link_to "Blog", blog_posts_path, class: "hover:text-gray-300" %>
           <% if logged_in? %>
             <span class="text-gray-300">Welcome, <%= current_user.name %></span>
             <% if current_user.superadmin? %>

--- a/config/locales/blog.en.yml
+++ b/config/locales/blog.en.yml
@@ -1,0 +1,20 @@
+en:
+  blog_posts:
+    index:
+      title: "The Blog"
+      subtitle: "Latest insights and updates"
+    show:
+      edit: "Edit"
+      back_to_blog: "Back to Blog"
+    not_found: "Blog post not found"
+    reading_time:
+      one: "%{count} min read"
+      other: "%{count} min read"
+    views:
+      one: "%{count} view"
+      other: "%{count} views"
+    rss:
+      title: "Blog - Eight"
+      description: "Latest blog posts from Eight"
+    atom:
+      title: "Blog - Eight"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,13 @@ Rails.application.routes.draw do
   get "/auth/:provider/callback", to: "sessions#create"
   get "/auth/failure", to: "sessions#failure"
   delete "/logout", to: "sessions#destroy"
+  
+  # Blog routes
+  resources :blog_posts, path: 'blog', only: [:index, :show] do
+    collection do
+      get :feed, defaults: { format: 'rss' }
+    end
+  end
 
   # Defines the root path route ("/")
   root "home#index"

--- a/db/migrate/20250725212718_create_blog_posts.rb
+++ b/db/migrate/20250725212718_create_blog_posts.rb
@@ -1,0 +1,47 @@
+class CreateBlogPosts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :blog_posts do |t|
+      # Basic content
+      t.string :title, null: false
+      t.string :slug, null: false
+      t.text :content, null: false
+      t.text :excerpt
+      t.integer :status, default: 0, null: false # 0: draft, 1: published, 2: archived
+      
+      # Author information
+      t.references :user, null: false, foreign_key: true
+      
+      # SEO fields
+      t.string :meta_title
+      t.text :meta_description
+      t.string :meta_keywords
+      t.string :canonical_url
+      t.string :og_title
+      t.text :og_description
+      t.string :og_image_url
+      t.string :twitter_card, default: 'summary_large_image'
+      t.string :twitter_title
+      t.text :twitter_description
+      t.string :twitter_image_url
+      
+      # Content metadata
+      t.integer :reading_time_minutes
+      t.string :featured_image_url
+      t.string :featured_image_alt
+      t.datetime :published_at
+      
+      # Schema.org structured data
+      t.json :structured_data, default: {}
+      
+      # Analytics
+      t.integer :views_count, default: 0
+      
+      t.timestamps
+    end
+    
+    add_index :blog_posts, :slug, unique: true
+    add_index :blog_posts, :status
+    add_index :blog_posts, :published_at
+    add_index :blog_posts, [:status, :published_at]
+  end
+end

--- a/db/migrate/20250725212758_create_tags.rb
+++ b/db/migrate/20250725212758_create_tags.rb
@@ -1,0 +1,13 @@
+class CreateTags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      
+      t.timestamps
+    end
+    
+    add_index :tags, :name, unique: true
+    add_index :tags, :slug, unique: true
+  end
+end

--- a/db/migrate/20250725212815_create_taggings.rb
+++ b/db/migrate/20250725212815_create_taggings.rb
@@ -1,0 +1,13 @@
+class CreateTaggings < ActiveRecord::Migration[8.0]
+  def change
+    create_table :taggings do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :taggable, polymorphic: true, null: false
+      
+      t.timestamps
+    end
+    
+    add_index :taggings, [:tag_id, :taggable_id, :taggable_type], unique: true, name: 'index_taggings_uniqueness'
+    add_index :taggings, [:taggable_type, :taggable_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_25_205853) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_25_212815) do
+  create_table "blog_posts", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "slug", null: false
+    t.text "content", null: false
+    t.text "excerpt"
+    t.integer "status", default: 0, null: false
+    t.integer "user_id", null: false
+    t.string "meta_title"
+    t.text "meta_description"
+    t.string "meta_keywords"
+    t.string "canonical_url"
+    t.string "og_title"
+    t.text "og_description"
+    t.string "og_image_url"
+    t.string "twitter_card", default: "summary_large_image"
+    t.string "twitter_title"
+    t.text "twitter_description"
+    t.string "twitter_image_url"
+    t.integer "reading_time_minutes"
+    t.string "featured_image_url"
+    t.string "featured_image_alt"
+    t.datetime "published_at"
+    t.json "structured_data", default: {}
+    t.integer "views_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["published_at"], name: "index_blog_posts_on_published_at"
+    t.index ["slug"], name: "index_blog_posts_on_slug", unique: true
+    t.index ["status", "published_at"], name: "index_blog_posts_on_status_and_published_at"
+    t.index ["status"], name: "index_blog_posts_on_status"
+    t.index ["user_id"], name: "index_blog_posts_on_user_id"
+  end
+
   create_table "identities", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider"
@@ -26,6 +59,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_25_205853) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_roles_on_name", unique: true
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id", null: false
+    t.string "taggable_type", null: false
+    t.integer "taggable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id", "taggable_id", "taggable_type"], name: "index_taggings_uniqueness", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+    t.index ["slug"], name: "index_tags_on_slug", unique: true
   end
 
   create_table "user_roles", force: :cascade do |t|
@@ -46,7 +100,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_25_205853) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "blog_posts", "users"
   add_foreign_key "identities", "users"
+  add_foreign_key "taggings", "tags"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "users"
 end

--- a/lib/tasks/blog.rake
+++ b/lib/tasks/blog.rake
@@ -1,0 +1,187 @@
+namespace :blog do
+  desc "Generate an example blog post"
+  task generate_example: :environment do
+    # Find or create a user for the blog post
+    user = User.first || User.create!(
+      email: "admin@example.com",
+      name: "Admin User"
+    )
+    
+    # Create sample tags
+    tags = %w[Technology Rails Ruby Programming Web Development].map do |tag_name|
+      Tag.find_or_create_by!(name: tag_name) do |tag|
+        tag.slug = tag_name.parameterize
+      end
+    end
+    
+    # Generate example blog post
+    blog_post = BlogPost.create!(
+      title: "Building Modern Web Applications with Rails #{Rails::VERSION::STRING}",
+      content: <<~CONTENT,
+        Rails continues to be one of the most productive frameworks for building modern web applications. With the release of Rails #{Rails::VERSION::STRING}, developers have access to even more powerful features that streamline development and improve performance.
+
+        ## Key Features in Modern Rails
+
+        ### Hotwire Integration
+        
+        Hotwire represents a paradigm shift in how we build interactive web applications. By sending HTML over the wire instead of JSON, we can create reactive user interfaces without writing much JavaScript.
+
+        ```ruby
+        class MessagesController < ApplicationController
+          def create
+            @message = Message.create!(message_params)
+            respond_to do |format|
+              format.turbo_stream
+              format.html { redirect_to messages_url }
+            end
+          end
+        end
+        ```
+
+        ### Active Record Improvements
+
+        Active Record continues to evolve with better performance and more intuitive APIs. The new features include:
+
+        - Improved query performance with better indexing strategies
+        - Enhanced connection pooling for better concurrency
+        - More flexible attribute API for custom types
+
+        ### Action Cable Enhancements
+
+        Real-time features have become essential in modern applications. Action Cable makes it easy to add WebSocket support to your Rails app:
+
+        ```ruby
+        class ChatChannel < ApplicationCable::Channel
+          def subscribed
+            stream_from "chat_\#{params[:room_id]}"
+          end
+          
+          def speak(data)
+            ActionCable.server.broadcast(
+              "chat_\#{params[:room_id]}",
+              message: data['message']
+            )
+          end
+        end
+        ```
+
+        ## Best Practices for Rails Development
+
+        ### 1. Keep Controllers Thin
+
+        Controllers should only handle HTTP-specific logic. Business logic belongs in models or service objects:
+
+        ```ruby
+        class OrdersController < ApplicationController
+          def create
+            @order = OrderService.new(order_params).process
+            
+            if @order.persisted?
+              redirect_to @order, notice: 'Order was successfully created.'
+            else
+              render :new
+            end
+          end
+        end
+        ```
+
+        ### 2. Use Strong Parameters
+
+        Always use strong parameters to protect against mass assignment vulnerabilities:
+
+        ```ruby
+        def user_params
+          params.require(:user).permit(:name, :email, :password)
+        end
+        ```
+
+        ### 3. Leverage Rails Conventions
+
+        Rails is built on the principle of "Convention over Configuration". Following Rails conventions leads to:
+
+        - More maintainable code
+        - Easier onboarding for new developers
+        - Better integration with gems and tools
+
+        ## Performance Optimization
+
+        ### Database Optimization
+
+        - Use proper indexes on foreign keys and frequently queried columns
+        - Avoid N+1 queries with includes and joins
+        - Use counter caches for association counts
+
+        ### Caching Strategies
+
+        Rails provides multiple caching layers:
+
+        1. **Page Caching**: For static pages
+        2. **Action Caching**: For pages with simple authentication
+        3. **Fragment Caching**: For partial views
+        4. **Low-level Caching**: For computed values
+
+        ```ruby
+        Rails.cache.fetch("expensive_calculation_\#{id}", expires_in: 1.hour) do
+          perform_expensive_calculation
+        end
+        ```
+
+        ## Testing Your Rails Application
+
+        A comprehensive test suite is crucial for maintaining code quality:
+
+        ```ruby
+        class UserTest < ActiveSupport::TestCase
+          test "should not save user without email" do
+            user = User.new(name: "John Doe")
+            assert_not user.save, "Saved the user without an email"
+          end
+        end
+        ```
+
+        ## Deployment Considerations
+
+        When deploying Rails applications to production:
+
+        1. Use environment variables for sensitive configuration
+        2. Enable SSL/TLS for all connections
+        3. Set up proper logging and monitoring
+        4. Configure background job processing
+        5. Implement proper error tracking
+
+        ## Conclusion
+
+        Rails continues to be an excellent choice for building web applications in #{Date.current.year}. Its mature ecosystem, convention-based approach, and continuous improvements make it a productive framework for developers of all skill levels.
+
+        Whether you're building a simple blog or a complex enterprise application, Rails provides the tools and patterns you need to succeed. The key is to understand and leverage Rails conventions while keeping your code clean, tested, and performant.
+
+        Happy coding!
+      CONTENT
+      excerpt: "Explore the latest features and best practices for building modern web applications with Ruby on Rails. Learn about Hotwire integration, performance optimization, and deployment strategies.",
+      status: :published,
+      user: user,
+      meta_title: "Building Modern Web Apps with Rails #{Rails::VERSION::STRING} - Complete Guide",
+      meta_description: "Learn how to build modern web applications with Rails #{Rails::VERSION::STRING}. Covers Hotwire, Active Record improvements, best practices, and performance optimization.",
+      meta_keywords: "Rails, Ruby on Rails, web development, Hotwire, Turbo, Stimulus, Active Record, web applications",
+      reading_time_minutes: 8,
+      featured_image_url: "https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=1200&h=630&fit=crop",
+      featured_image_alt: "Code editor showing Ruby on Rails code",
+      published_at: 1.day.ago,
+      views_count: rand(100..1000)
+    )
+    
+    # Add tags to the blog post
+    blog_post.tags = tags.sample(3)
+    
+    puts "✅ Created example blog post: #{blog_post.title}"
+    puts "   URL: /blog/#{blog_post.slug}"
+    puts "   Tags: #{blog_post.tags.pluck(:name).join(', ')}"
+    puts "   Author: #{blog_post.user.name}"
+  end
+  
+  desc "Delete all example blog posts"
+  task delete_examples: :environment do
+    count = BlogPost.where("title LIKE ?", "%Building Modern Web Applications with Rails%").destroy_all.count
+    puts "✅ Deleted #{count} example blog post(s)"
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a comprehensive blog feature to the Eight application
- Includes modern SEO capabilities, internationalization, and a flexible tagging system
- Styled with NYT-inspired design using Tailwind CSS

## Features Added

### Database Schema
- Blog posts table with comprehensive SEO fields (meta tags, Open Graph, Twitter cards)
- Polymorphic tagging system with tags and taggings tables
- Support for draft, published, and archived post statuses

### Models
- BlogPost model with status enum, slug generation, and SEO defaults
- Tag model with automatic slug generation
- Tagging model for polymorphic associations

### Controllers & Views
- BlogPostsController with index and show actions
- NYT-style responsive blog layout
- Simple pagination without external dependencies
- RSS and Atom feed support

### Additional Features
- Internationalization support for all blog text
- Rake tasks for generating and deleting example blog posts
- Blog link added to main navigation
- View count tracking for analytics

## Test plan
- [ ] Run `rails blog:generate_example` to create a sample blog post
- [ ] Visit `/blog` to see the blog index page
- [ ] Click on a blog post to view the full article
- [ ] Check RSS feed at `/blog.rss`
- [ ] Check Atom feed at `/blog.atom`
- [ ] Verify responsive design on mobile and desktop
- [ ] Run `rails blog:delete_examples` to clean up test data

🤖 Generated with [Claude Code](https://claude.ai/code)